### PR TITLE
Fix double-encoded query

### DIFF
--- a/src/js/jquery.stackview.base.js
+++ b/src/js/jquery.stackview.base.js
@@ -95,7 +95,7 @@
 				params.query = [
 					'[',
 					stack.loc.low,
-					'%20TO%20',
+					' TO ',
 					stack.loc.high,
 					']'
 				].join('');
@@ -104,7 +104,7 @@
 				params.query = [
 					'[',
 					stack.loc.high + 1,
-					'%20TO%20',
+					' TO ',
 					stack.loc.high + opts.items_per_page + 1,
 					']'
 				].join('');
@@ -114,7 +114,7 @@
 				params.query = [
 					'[',
 					stack.loc.low - opts.items_per_page - 1,
-					'%20TO%20',
+					' TO ',
 					stack.loc.low - 1,
 					']'
 				].join('');


### PR DESCRIPTION
In `loc_sort_order` mode, the query range was getting double-encoded,
eg:

    &query=%5B95%2520TO%2520105%5D

This is because the string was
[produced with encoded literals](https://github.com/harvard-lil/stackview/blob/f1bd956b3304c414bd66cadd07006641ef47d7c6/src/js/jquery.stackview.base.js#L98),
but then [passed to $.param](https://github.com/harvard-lil/stackview/blob/f1bd956b3304c414bd66cadd07006641ef47d7c6/src/js/jquery.stackview.base.js#L138)
 which encoded it again.

This problem does not exist in the stacklife demo, I'm guessing
stacklife is using a fork of stackview which already has this bug
fixed?

At any rate, after this patch, query range string looks like this:

    &query=%5B95+TO+105%5D

Which matches how it looks in the stacklife demo.

----------

This PR does _not_ include a changed jquery.stackview.min.js, because it would produce conflicts with other outstanding PR's. After all PR's are merged, a new jquery.stackview.min.js will have to be generated. 