### PR TITLE
generic-decoration mixin with .item-colors class

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -83,7 +83,15 @@
 	}
 }
 
+@mixin generic-decoration($bg, $border) {
+	.item-colors {
+		background:$bg;
+		border-color:$border;
+	}
+}
+
 @mixin decorations($bg, $border) {
+	@include generic-decoration($bg, $border);
 	@include book-decoration($bg, $border);
 	@include videofilm-decoration($bg, $border);
 	@include serial-decoration($bg, $border);


### PR DESCRIPTION
One challenge in creating a local 'type' display is getting
the proper heatmap colors in edge and top. Existing types all
use their own custom classes, which need to be included in the
decorations mixin to set appropriate per-heatmap colors.

We want to be able to add a new type without having to edit
the decorations mixin.

So this change adds a generic .item-colors class that will have
appropriate colors for the current heatmap. A custom type can
use this class, already provided, instead of having to somehow
get it's own classes into the decorations mixin.