### PR TITLE
Hide empty .spine-date

### DIFF
--- a/src/scss/jquery.stackview.scss
+++ b/src/scss/jquery.stackview.scss
@@ -125,6 +125,10 @@
 	border-color:#e6dec4;
 	text-shadow:none;
 	color:#555;
+
+	&:empty {
+		display: none;
+	}
 }
 
 .stackview .ribbon {


### PR DESCRIPTION
If no date value is given, previously you still get a spine date
label showing, but blank.

After this change, the spine date label is not there, hidden with
display-none.

Is this desirable? It is for me, but if it's not for stackview it's easy enough for me to add a line of custom CSS to my own app to do it. 

----
To avoid conflicts with other PRs, this PR does not include regenerated aggregated CSS, it will have to be rebuilt. 