### PR TITLE
Serial .spine-title width needs to be reduced

### DIFF
--- a/src/scss/_serial.scss
+++ b/src/scss/_serial.scss
@@ -15,7 +15,7 @@
 		left:15px;
 		top:0;
 		bottom:0;
-		width:200px;
+		width:185px;
 	}
 
 	.spine-title {


### PR DESCRIPTION
By 15px, to take account of the left:15px. Before this change,
long serial titles go out of the bounds they are meant to
in the graphic.