### PR TITLE
prevent soundrecording title from overflowing...

### DIFF
--- a/src/scss/_soundrecording.scss
+++ b/src/scss/_soundrecording.scss
@@ -19,6 +19,7 @@
 
 	.spine-text {
 		left:35px;
+		right: 35px;
 	}
 
 	.spine-title {


### PR DESCRIPTION
...out of graphic. Modelled it on what book type does, add
a CSS right to provide spacing, like book has. After this change,
titles no longer overflow past graphic -- sometimes they do
go under the date label, which I think is fine or even as desired.