### PR TITLE
Fix styling of .stack-pages:after

### DIFF
--- a/src/scss/_book.scss
+++ b/src/scss/_book.scss
@@ -44,9 +44,9 @@
 		bottom:0;
 		background:#f5f2e8;
 		border-radius:3px 0 0 3px / 20px 0 0 20px;
-		border-width:2px 1px 2px 0px;
-		border-style:solid;
-		border-color:#aaa #e5e5e5 #007acc #ddd;
+		border-width:3px 1px 2px 0px;
+		border-style:solid dotted solid solid;
+		border-color:#aaa #e0d7b9 #ccc #ccc;
 	}
 }
 


### PR DESCRIPTION
The new styling matches what I reverse engineered from
the stacklife demo, and has slightly different border
color/width/style then was actually in the stackview repo.

What was in stacklife demo looks a lot better. So this PR.

Is stacklife using a fork of this stackview code? Possibly
with various improvements? Is there any easy way for me to diff
between what stacklife is actually using and stackview, and see
if there are any other missing improvements?