### PR TITLE
Stackview init, DEEP extend options with defaults

### DIFF
--- a/src/js/jquery.stackview.base.js
+++ b/src/js/jquery.stackview.base.js
@@ -168,7 +168,7 @@
 	StackView = function(elem, opts) {
 		this.element = elem;
 		this.$element = $(elem);
-		this.options = $.extend({}, StackView.defaults, opts);
+		this.options = $.extend(true, {}, StackView.defaults, opts);
 		this.page = 0;
 		this.finished = {
 			up: false,


### PR DESCRIPTION
This lets you over-ride just one element of a sub-object option,
and inherit the defaults for the others, like:

~~~
   $("something").stackview({
      book: {
        max_pages: 100
      },
      etc
    });
~~~

Override just book.max_pages, while accepting defaults
for other book.*.

Good idea, I think?  It does mean that in change to before, if you
wanted to ERASE certain defaults, it's harder, they don't get
erased just by leaving them out of your init params. But I don't
think that's ever a sensible thing to do.